### PR TITLE
Updated email redirect URL in signup process

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -67,7 +67,10 @@ export default function SignupPage() {
     setGeneralError(null)
     setInfo(null)
 
-    const emailRedirectTo = `${window.location.origin}/auth/confirmation`
+    const appUrl =
+      (process.env.NEXT_PUBLIC_APP_URL?.trim().replace(/\/+$/, "") ||
+        window.location.origin) as string
+    const emailRedirectTo = `${appUrl}/auth/confirmation`
 
     const { data, error } = await supabase.auth.signUp({
       email: values.email,


### PR DESCRIPTION
- Changed the email redirect URL to use the application URL from environment variables, ensuring consistency across different environments.
- Changed the **Site URL** and **Redirect URL** in Supabase to `https://gatherly-frontend-one.vercel.app` and `https://gatherly-frontend-one.vercel.app/auth/confirmation` respectively.

Fixes #21 