### PR TITLE
Update event detail schema to allow optional organizer field

### DIFF
--- a/lib/api/event-detail-schema.ts
+++ b/lib/api/event-detail-schema.ts
@@ -24,11 +24,13 @@ export const publicEventDetailSchema = z.object({
   maxCapacity: z.number(),
   isHot: z.boolean(),
   categories: z.array(z.string()),
+  // API may omit this with no JWT, or send `null` when unauthenticated.
   organizer: z
     .object({
       id: z.string().uuid(),
       fullName: z.string(),
     })
+    .nullable()
     .optional(),
 })
 


### PR DESCRIPTION
- Made the `organizer` field nullable and optional in the event detail schema to accommodate cases where the API may omit this information for unauthenticated requests.

Fixes #52